### PR TITLE
Fix to gpg signature verification

### DIFF
--- a/libopkg/opkg_gpg.c
+++ b/libopkg/opkg_gpg.c
@@ -158,9 +158,6 @@ int opkg_verify_gpg_signature(const char *file, const char *sigfile)
     gpgme_signature_t s;
     char *trusted_path = NULL;
 
-    if (opkg_config->check_signature == 0)
-        return 0;
-
     if (gpgme_init()) {
         opkg_msg(ERROR, "GPGME Failed to initalize.\n");
         goto out_err;


### PR DESCRIPTION
@opkg-devel@googlegroups.com
Per package signature verification required "check_signature" option to be enabled.
This bug has been resolved by removing this configuration option check.
